### PR TITLE
Clone Linux repo to correct dir in dashboard

### DIFF
--- a/src/dashboard/app.rs
+++ b/src/dashboard/app.rs
@@ -234,7 +234,7 @@ fn init_linux_repo() -> Result<()> {
     if !Path::new(format!("{}/.git", LINUX_REPO_PATH).as_str()).exists() {
         Command::new("git")
             .current_dir(LINUX_REPO_PATH)
-            .args(["clone", LINUX_REPO_URL])
+            .args(["clone", LINUX_REPO_URL, LINUX_REPO_PATH])
             .spawn()?
             .wait()?;
     }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to TuxTape.
Please take a moment to fill out the template to help us understand your changes better.
-->

**Issue Number:**
_Reference the issue this PR fixes._

N/A

**Description of Changes:**
_Provide a clear and concise explanation of what changes you made and why._

Clone Linux repo into `~/.cache/tuxtape-dashboard/git/linux` instead of `~/.cache/tuxtape-dashboard/git/linux/linux`.

**Testing Done:**
_How did you test your changes? Share details like steps, tools used, or results._

I have run this change on a fresh build of TuxTape.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is licensed under the terms of the Apache License, Version 2.0.


---

Thanks for submitting your pull request! We will review it as soon as possible.

